### PR TITLE
Solve: 프로그래머스 - 성격 유형 검사하기

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[.js]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[.py]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/Programmers/성격_유형_검사하기/__init__.py
+++ b/Programmers/성격_유형_검사하기/__init__.py
@@ -1,0 +1,45 @@
+def solution(survey, choices):
+    MBTI = {}
+    types = ["RT", "CF", "JM", "AN"]
+
+    for type in types:
+        for char in list(type):
+            MBTI[char] = 0
+
+    for i, choice in enumerate(choices):
+        [disagree, agree] = survey[i]
+
+        MBTI[agree if choice > 4 else disagree] += abs(choice - 4)
+    
+    return "".join(list(map(lambda type: type[1] if MBTI[type[1]] > MBTI[type[0]] else type[0] ,types)))
+
+# 입력부
+# solution(["AN", "CF", "MJ", "RT", "NA"], [5, 3, 2, 7, 5])   # "TCMA"
+# solution(["TR", "RT", "TR"], [7, 1, 3]);    # "RCJA"
+
+# [NOTE]
+# 1. enumerate()
+# + 기본적으로 "인덱스" 와 "원소" 순으로 이뤄진 튜플(tuple) 을 만들어줌
+# + 인덱스와 원소를 각각 사용하기 위해서는 인자 풀기(unpacking)을 해줘야함
+# + 참고: https://www.daleseo.com/python-enumerate/
+
+# 2. list(공백없는 문자열) -> 문자열 하나씩 자른 배열 반환
+# + 참고: https://codechacha.com/ko/python-convert-string-to-char-list/
+
+# 3. 파이썬 딕셔너리는 존재하지 않는 키에 접근시 KeyError 를 발생시킴
+# + 사전에 필요한 딕셔너리 "my_dict.key = value" 형태로 초기화를 시키면 error 를 피할 수 있음
+# + 참고: https://korbillgates.tistory.com/95
+
+# 4. 파이썬 map 에 callback 함수 사용하는 법(with. Lambda Function) + 파이썬 map 을 활용하는 법
+# + 참고: https://zetcode.com/python/lambda/
+
+# 5. 파이썬 문자열 배열 데이터 join 으로 하나의 문자열 만들기
+# + seperator.join(array)
+# + 참고: https://blockdmask.tistory.com/468
+
+# 6. 파이썬 삼항 연산자 사용법
+# + [on_true] if [expression] else [on_false]
+# + 참고: https://codechacha.com/ko/python-ternary-operation/
+
+
+

--- a/Programmers/성격_유형_검사하기/index.js
+++ b/Programmers/성격_유형_검사하기/index.js
@@ -1,0 +1,45 @@
+function solution(survey, choices) {
+  const typesMap = new Map();
+  ["R", "T", "C", "F", "J", "M", "A", "N"].forEach((type) => typesMap.set(type, 0));
+
+  choices.forEach((choice, i) => {
+    const [disagree, agree] = survey[i];
+
+    if (choice > 4) {
+      typesMap.set(agree, typesMap.get(agree) + Math.abs(choice - 4));
+    }
+
+    if (choice < 4) {
+      typesMap.set(disagree, typesMap.get(disagree) + Math.abs(choice - 4));
+    }
+  });
+
+  return getMBTI(typesMap);
+}
+
+const getMBTI = (map) => {
+  let result = "";
+
+  result = result + (map.get("R") >= map.get("T") ? "R" : "T");
+  result = result + (map.get("C") >= map.get("F") ? "C" : "F");
+  result = result + (map.get("J") >= map.get("M") ? "J" : "M");
+  result = result + (map.get("A") >= map.get("N") ? "A" : "N");
+
+  return result;
+};
+
+// 입력부
+// solution(["AN", "CF", "MJ", "RT", "NA"], [5, 3, 2, 7, 5]); // "TCMA"
+// solution(["TR", "RT", "TR"], [7, 1, 3]); // "RCJA"
+
+/**
+ * 문제: 프로그래머스 - 성격 유형 검사하기
+ * 테마: 구현
+ * 링크: https://school.programmers.co.kr/learn/courses/30/lessons/118666?language=javascript
+ *
+ * [NOTE]
+ * - 각 질문에 대해, 지표에서 4점(잘 모르겠음, 0점)을 기준으로, 유형 선택이 달라지는 것을 파악
+ * - 각 질문에 대해, 유형 순서(survey 요소)의 순서가 보장되어 있지 않음을 파악
+ *   -> 점수에 따라 추출되는 유형을 기반으로 빠르게 접근하기 위해 Map 자료형 사용
+ * - 지표마다 두 유형의 점수가 같은 경우, 사전 순으로 빠른 유형을 선택한다는 점 반영
+ */


### PR DESCRIPTION
## 어려웠던 점
- 파이썬에서는 자바스크립트의 `forEach 문` 과 같이 배열에 콜백함수 파라미터를 통해 인덱스 값을 접근하는 방법이 없었습니다. 찾아보니 파이썬에는 `enumerate` 함수가 존재하고 리스트의 각 요소에 대해 인덱스 값을 가진 튜플을 반환하고 이것을 `unpacking` 을 통해 `for ~ in` 문에서 사용할 수 있다는 것을 알게 되었습니다.
- 자바스크립트의 `join` 함수와 파이썬의 'join` 함수 사용하는 순서가 완전히 반대여서 헷갈렸습니다.. 😂

## 고민한 점
- 결국 마지막에는 각 성격 유형의 누적 점수에 접근을 해야하는데 이 데이터를 효율적으로 하기위해 어떤 자료구조를 사용 ?
  - Map 자료형
- 하나의 지표에 포함된 두 성격유형의 누적 점수가 같으면 사전순으로 빠른 성격유형 알파벳 적용을 어떻게 구분 ? (단, 각 지표에 담겨있는 성격유형 순서가 보장되어 있지 않다.) 
  - 최종 MBTI 를 생성하는 메서드를 생성했다.
  - 각 지표에 정해진 두 성격 지표에 대해 알파벳 순서는 정해져 있으니 삼항 연산자를 적용( 하드코딩이긴 함 )


